### PR TITLE
Fix to make matching results clearer

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: variantstring
 Type: Package
 Title: Functions for working with variant string format
-Version: 1.5.0
+Version: 1.5.1
 Authors@R: c(
     person("Bob", "Verity", email = "r.verity@imperial.ac.uk", role = c("aut", "cre"))
     )

--- a/R/main.R
+++ b/R/main.R
@@ -885,7 +885,7 @@ compare_variant_string <- function(target_string, comparison_strings) {
 
     # get if a match over all loci, and if match is ambiguous
     ret$match[i] <- all(df_match$match == 1)
-    ret$ambiguous[i] <- (sum(df_match$het) > 1)
+    ret$ambiguous[i] <- (sum(df_match$het) > 1) & ret$match[i]
 
     if (sum(df_match$het) == 0) {
       ret$prop[i] <- ret$match[i]

--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ There are also a few more utility functions not listed here - see the package he
 
 ## Release history
 
-The current version is 1.5.0, released 16 Jan 2025.
+The current version is 1.5.1, released 16 Jan 2025.


### PR DESCRIPTION
hotfix, match function could say that a result was ambiguous even when there was no match